### PR TITLE
Improve CI actions cache

### DIFF
--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -35,13 +35,15 @@ runs:
       run: |
         conan config install conan/global.conf
 
-    - name: Get Conan cache location
+    - name: Set environment variables
       if: ${{ runner.os == 'Linux' }}
       shell: ${{ inputs.shell }}
       run: |
           echo "CONAN_CACHE_LOCATION=$(conan config home)" >> $GITHUB_ENV
+          echo "COMPILER_NAME=${{ inputs.compiler }}" >> $GITHUB_ENV
+          echo "COMPILER_VERSION=${{ inputs.compiler-version }}" >> $GITHUB_ENV
 
-    - name: Get Conan cache location
+    - name: Set environment variables
       if: ${{ runner.os == 'Windows' }}
       shell: ${{ inputs.shell }}
       run: |
@@ -68,29 +70,16 @@ runs:
     - name: Override public Conan recipes
       shell: ${{ inputs.shell }}
       run: |
-        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan create recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1 --build=missing
-        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan create recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2 --build=missing
+        conan create recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1 --build=missing
+        conan create recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2 --build=missing
 
     - name: Override Linux specific public Conan recipes
       if: ${{ runner.os == 'Linux' }}
       shell: ${{ inputs.shell }}
       run: |
-        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan create recipes/recipes/pulseaudio/meson --profile=ci/conan/${{ inputs.profile }} --version 17.0 --build=missing
+        conan create recipes/recipes/pulseaudio/meson --profile=ci/conan/${{ inputs.profile }} --version 17.0 --build=missing
 
-    - name: Build all GCC dependencies
-      if: ${{ inputs.compiler == 'gcc' }}
-      shell: ${{ inputs.shell }}
-      run: |
-        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/${{ inputs.profile }}
-
-    - name: Build all Clang dependencies
-      if: ${{ inputs.compiler == 'clang' }}
-      shell: ${{ inputs.shell }}
-      run: |
-        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/${{ inputs.profile }}
-
-    - name: Build all MSVC dependencies
-      if: ${{ inputs.compiler == 'msvc' }}
+    - name: Build all dependencies
       shell: ${{ inputs.shell }}
       run: |
         conan install . --build=missing --profile=ci/conan/${{ inputs.profile }}

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -71,13 +71,13 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       shell: ${{ inputs.shell }}
       run: |
-        conan create recipes/recipes/pulseaudio/meson --profile=ci/conan/${{ inputs.profile }} --version 17.0 --build=missing
+        conan export recipes/recipes/pulseaudio/meson --profile=ci/conan/${{ inputs.profile }} --version 17.0
 
     - name: Override public Conan recipes
       shell: ${{ inputs.shell }}
       run: |
-        conan create recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1 --build=missing
-        conan create recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2 --build=missing
+        conan export recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1
+        conan export recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2
 
     - name: Build all dependencies
       shell: ${{ inputs.shell }}

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -41,7 +41,7 @@ runs:
       run: |
           echo "CONAN_CACHE_LOCATION=$(conan config home)" >> $GITHUB_ENV
           echo "COMPILER_NAME=${{ inputs.compiler }}" >> $GITHUB_ENV
-          echo "COMPILER_VERSION=${{ inputs.compiler-version }}" >> $GITHUB_ENV
+          echo "COMPILER_VER=${{ inputs.compiler-version }}" >> $GITHUB_ENV
 
     - name: Set environment variables
       if: ${{ runner.os == 'Windows' }}

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -54,7 +54,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ env.CONAN_CACHE_LOCATION }}/p
-        key: ${{ github.job }}-${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ hashFiles('conanfile.py') }}
+        key: ${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ hashFiles('conanfile.py') }}
         
     - name: Detect default profile
       shell: ${{ inputs.shell }}
@@ -78,3 +78,27 @@ runs:
       shell: ${{ inputs.shell }}
       run: |
         conan create recipes/recipes/pulseaudio/meson --profile=conan/${{ inputs.compiler }}-${{ inputs.compiler-version }} --profile=conan/dependencies --version 17.0 --build=missing -s build_type=${{ inputs.build-type }}
+
+    - name: Build all GCC dependencies
+      if: ${{ inputs.compiler == 'gcc' }}
+      shell: ${{ inputs.shell }}
+      run: |
+          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/linux-hardened
+          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/static-analysis
+          conan install . --build=missing --profile=ci/conan/gcc-tsan
+
+    - name: Build all Clang dependencies
+      if: ${{ inputs.compiler == 'gcc' }}
+      shell: ${{ inputs.shell }}
+      run: |
+          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/linux-hardened
+          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/static-analysis
+          conan install . --build=missing --profile=ci/conan/clang-asan-leak-undefined
+
+    - name: Build all MSVC dependencies
+      if: ${{ inputs.compiler == 'msvc' }}
+      shell: ${{ inputs.shell }}
+      run: |
+          conan install . --build=missing --profile=ci/conan/msvc-hardened
+          conan install . --build=missing --profile=ci/conan/msvc-analyze
+          conan install . --build=missing --profile=ci/conan/msvc-asan

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -88,7 +88,7 @@ runs:
           conan install . --build=missing --profile=ci/conan/gcc-tsan
 
     - name: Build all Clang dependencies
-      if: ${{ inputs.compiler == 'gcc' }}
+      if: ${{ inputs.compiler == 'clang' }}
       shell: ${{ inputs.shell }}
       run: |
           COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/linux-hardened

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -67,17 +67,17 @@ runs:
         repository: jan-kelemen/conan-recipes
         path: recipes
 
-    - name: Override public Conan recipes
-      shell: ${{ inputs.shell }}
-      run: |
-        conan create recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1 --build=missing
-        conan create recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2 --build=missing
-
     - name: Override Linux specific public Conan recipes
       if: ${{ runner.os == 'Linux' }}
       shell: ${{ inputs.shell }}
       run: |
         conan create recipes/recipes/pulseaudio/meson --profile=ci/conan/${{ inputs.profile }} --version 17.0 --build=missing
+
+    - name: Override public Conan recipes
+      shell: ${{ inputs.shell }}
+      run: |
+        conan create recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1 --build=missing
+        conan create recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2 --build=missing
 
     - name: Build all dependencies
       shell: ${{ inputs.shell }}

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -10,8 +10,8 @@ inputs:
     description: 'Target architecture'
     required: false
     default: 'x64'
-  build-type:
-    description: 'Used build type'
+  profile:
+    description: 'Used profile'
     required: true
   shell:
     description: 'Used shell for executing commands'
@@ -21,9 +21,7 @@ inputs:
     description: 'Version to install'
     required: false
     default: 2.2.1
-outputs:
-  conan-profile:
-    value: conan/${{inputs.arch == 'aarch64' && 'aarch64-' || ''}}${{ inputs.compiler }}-${{ inputs.compiler-version }}
+
 runs:
   using: 'composite'
   steps:
@@ -54,7 +52,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ env.CONAN_CACHE_LOCATION }}/p
-        key: ${{ inputs.compiler }}-${{ inputs.compiler-version }}-${{ hashFiles('conanfile.py') }}
+        key: ${{ inputs.compiler }}-${{ inputs.profile }}-${{ hashFiles('conanfile.py') }}
         
     - name: Detect default profile
       shell: ${{ inputs.shell }}
@@ -70,35 +68,29 @@ runs:
     - name: Override public Conan recipes
       shell: ${{ inputs.shell }}
       run: |
-        conan create recipes/recipes/sdl/all --profile=conan/${{ inputs.compiler }}-${{ inputs.compiler-version }} --profile=conan/dependencies --version 2.30.1 --build=missing -s build_type=${{ inputs.build-type }}
-        conan create recipes/recipes/freetype/meson --profile=conan/${{ inputs.compiler }}-${{ inputs.compiler-version }} --profile=conan/dependencies --version 2.13.2 --build=missing -s build_type=${{ inputs.build-type }}
+        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan create recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1 --build=missing
+        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan create recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2 --build=missing
 
     - name: Override Linux specific public Conan recipes
       if: ${{ runner.os == 'Linux' }}
       shell: ${{ inputs.shell }}
       run: |
-        conan create recipes/recipes/pulseaudio/meson --profile=conan/${{ inputs.compiler }}-${{ inputs.compiler-version }} --profile=conan/dependencies --version 17.0 --build=missing -s build_type=${{ inputs.build-type }}
+        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan create recipes/recipes/pulseaudio/meson --profile=ci/conan/${{ inputs.profile }} --version 17.0 --build=missing
 
     - name: Build all GCC dependencies
       if: ${{ inputs.compiler == 'gcc' }}
       shell: ${{ inputs.shell }}
       run: |
-          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/linux-hardened
-          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/static-analysis
-          conan install . --build=missing --profile=ci/conan/gcc-tsan
+        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/${{ inputs.profile }}
 
     - name: Build all Clang dependencies
       if: ${{ inputs.compiler == 'clang' }}
       shell: ${{ inputs.shell }}
       run: |
-          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/linux-hardened
-          COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/static-analysis
-          conan install . --build=missing --profile=ci/conan/clang-asan-leak-undefined
+        COMPILER_NAME=${{ inputs.compiler }} COMPILER_VER=${{ inputs.compiler-version }} conan install . --build=missing --profile=ci/conan/${{ inputs.profile }}
 
     - name: Build all MSVC dependencies
       if: ${{ inputs.compiler == 'msvc' }}
       shell: ${{ inputs.shell }}
       run: |
-          conan install . --build=missing --profile=ci/conan/msvc-hardened
-          conan install . --build=missing --profile=ci/conan/msvc-analyze
-          conan install . --build=missing --profile=ci/conan/msvc-asan
+        conan install . --build=missing --profile=ci/conan/${{ inputs.profile }}

--- a/.github/actions/setup-conan/action.yml
+++ b/.github/actions/setup-conan/action.yml
@@ -71,13 +71,13 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       shell: ${{ inputs.shell }}
       run: |
-        conan export recipes/recipes/pulseaudio/meson --profile=ci/conan/${{ inputs.profile }} --version 17.0
+        conan export recipes/recipes/pulseaudio/meson --version 17.0
 
     - name: Override public Conan recipes
       shell: ${{ inputs.shell }}
       run: |
-        conan export recipes/recipes/sdl/all --profile=ci/conan/${{ inputs.profile }} --version 2.30.1
-        conan export recipes/recipes/freetype/meson --profile=ci/conan/${{ inputs.profile }} --version 2.13.2
+        conan export recipes/recipes/sdl/all --version 2.30.1
+        conan export recipes/recipes/freetype/meson --version 2.13.2
 
     - name: Build all dependencies
       shell: ${{ inputs.shell }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,7 @@ jobs:
         with:
           compiler: ${{ matrix.compiler }}
           compiler-version: ${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }}
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --profile=ci/conan/linux-hardened
+          profile: linux-hardened
 
       - name: Configure CMake
         run: |
@@ -87,11 +83,7 @@ jobs:
         with:
           compiler: msvc
           compiler-version: 2022
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=ci/conan/msvc-hardened
+          profile: msvc-hardened
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/linux-hardened
+          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --profile=ci/conan/linux-hardened
 
       - name: Configure CMake
         run: |
@@ -91,7 +91,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --build=missing --profile=ci/conan/msvc-hardened
+          conan install . --profile=ci/conan/msvc-hardened
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile conan/dependencies --profile conan/opt/linux-hardening --build=missing --settings build_type=Release
+          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/linux-hardened
 
       - name: Configure CMake
         run: |
@@ -91,7 +91,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --profile=conan/opt/msvc-hardening --build=missing --settings build_type=Release
+          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --build=missing --profile=ci/conan/msvc-hardened
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -39,11 +39,7 @@ jobs:
         with:
           compiler: clang
           compiler-version: ${{ env.CLANG_VER }}
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=ci/conan/clang-asan-leak-undefined
+          profile: clang-asan-leak-undefined
 
       - name: Configure CMake
         run: |
@@ -82,11 +78,7 @@ jobs:
         with:
           compiler: gcc
           compiler-version: ${{ env.GCC_VER }}
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=ci/conan/gcc-tsan
+          profile: gcc-tsan
 
       - name: Configure CMake
         run: |
@@ -123,11 +115,7 @@ jobs:
         with:
           compiler: msvc
           compiler-version: 2022
-          build-type: Release
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=ci/conan/msvc-asan
+          profile: msvc-asan
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --profile=conan/opt/linux-address-sanitizer --profile=conan/opt/linux-leak-sanitizer --profile=conan/opt/linux-undefined-sanitizer --build=missing --settings build_type=Release
+          conan install . --build=missing --profile=ci/conan/clang-asan-leak-undefined
 
       - name: Configure CMake
         run: |
@@ -86,7 +86,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --profile=conan/opt/linux-thread-sanitizer --build=missing --settings build_type=Release
+          conan install . --build=missing --profile=ci/conan/gcc-tsan
 
       - name: Configure CMake
         run: |
@@ -127,7 +127,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --profile=conan/opt/msvc-address-sanitizer --build=missing --settings build_type=Release
+          conan install . --build=missing --profile=ci/conan/msvc-asan
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --build=missing --profile=ci/conan/clang-asan-leak-undefined
+          conan install . --profile=ci/conan/clang-asan-leak-undefined
 
       - name: Configure CMake
         run: |
@@ -86,7 +86,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --build=missing --profile=ci/conan/gcc-tsan
+          conan install . --profile=ci/conan/gcc-tsan
 
       - name: Configure CMake
         run: |
@@ -127,7 +127,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --build=missing --profile=ci/conan/msvc-asan
+          conan install . --profile=ci/conan/msvc-asan
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -94,7 +94,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -133,7 +133,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -215,7 +215,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --build=missing --profile=ci/conan/msvc-analyze
+          conan install . --profile=ci/conan/msvc-analyze
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -94,7 +94,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -133,7 +133,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
+          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile conan/dependencies --build=missing --settings build_type=Debug
+          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -94,7 +94,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --build=missing --settings build_type=Debug
+          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -133,7 +133,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --build=missing --settings build_type=Debug
+          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -175,7 +175,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --build=missing --settings build_type=Debug
+          COMPILER_NAME=${{ matrix.compiler }} COMPILER_VER=${{ matrix.compiler == 'gcc' && env.GCC_VER || env.CLANG_VER }} conan install . --build=missing --profile=ci/conan/static-analysis
 
       - name: Configure CMake
         run: |
@@ -215,7 +215,7 @@ jobs:
 
       - name: Fetch dependencies
         run: |
-          conan install . --profile=${{ steps.setup-conan.outputs.conan-profile }} --profile=conan/dependencies --build=missing --settings build_type=Debug
+          conan install . --build=missing --profile=ci/conan/msvc-analyze
 
       - name: Configure CMake
         run: |

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -42,11 +42,7 @@ jobs:
         with:
           compiler: clang
           compiler-version: ${{ env.CLANG_VER }}
-          build-type: Debug
-
-      - name: Fetch dependencies
-        run: |
-          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --profile=ci/conan/static-analysis
+          profile: static-analysis
 
       - name: Configure CMake
         run: |
@@ -90,11 +86,7 @@ jobs:
         with:
           compiler: clang
           compiler-version: ${{ env.CLANG_VER }}
-          build-type: Debug
-
-      - name: Fetch dependencies
-        run: |
-          COMPILER_NAME=clang COMPILER_VER=${{ env.CLANG_VER }} conan install . --profile=ci/conan/static-analysis
+          profile: static-analysis
 
       - name: Configure CMake
         run: |
@@ -129,11 +121,7 @@ jobs:
         with:
           compiler: gcc
           compiler-version: ${{ env.GCC_VER }}
-          build-type: Debug             
-
-      - name: Fetch dependencies
-        run: |
-          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --profile=ci/conan/static-analysis
+          profile: static-analysis             
 
       - name: Configure CMake
         run: |
@@ -171,11 +159,7 @@ jobs:
         with:
           compiler: gcc
           compiler-version: ${{ env.GCC_VER }}
-          build-type: Debug             
-
-      - name: Fetch dependencies
-        run: |
-          COMPILER_NAME=gcc COMPILER_VER=${{ env.GCC_VER }} conan install . --profile=ci/conan/static-analysis
+          profile: static-analysis             
 
       - name: Configure CMake
         run: |
@@ -211,11 +195,7 @@ jobs:
         with:
           compiler: msvc
           compiler-version: 2022
-          build-type: Debug
-
-      - name: Fetch dependencies
-        run: |
-          conan install . --profile=ci/conan/msvc-analyze
+          profile: msvc-analyze
 
       - name: Configure CMake
         run: |

--- a/ci/conan/clang-asan-leak-undefined
+++ b/ci/conan/clang-asan-leak-undefined
@@ -1,0 +1,9 @@
+include(../../conan/clang-{{ os.getenv("CLANG_VER") }})
+include(../../conan/dependencies)
+include(../../conan/opt/linux-address-sanitizer)
+include(../../conan/opt/linux-leak-sanitizer)
+include(../../conan/opt/linux-undefined-sanitizer)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/gcc-tsan
+++ b/ci/conan/gcc-tsan
@@ -1,0 +1,7 @@
+include(../../conan/gcc-{{ os.getenv("GCC_VER") }})
+include(../../conan/dependencies)
+include(../../conan/opt/linux-thread-sanitizer)
+
+[settings]
+build_type=Release
+

--- a/ci/conan/linux-hardened
+++ b/ci/conan/linux-hardened
@@ -1,6 +1,6 @@
 include(../../conan/{{ os.getenv("COMPILER_NAME")}}-{{ os.getenv("COMPILER_VER") }})
 include(../../conan/dependencies)
-include(../../conan/opt/linux-hardening)
+include(../../conan/opt/{{ os.getenv("COMPILER_NAME")-linux-hardening)
 
 [settings]
 build_type=Release

--- a/ci/conan/linux-hardened
+++ b/ci/conan/linux-hardened
@@ -1,6 +1,6 @@
-include(../../conan/{{ os.getenv("COMPILER_NAME")}}-{{ os.getenv("COMPILER_VER") }})
+include(../../conan/{{ os.getenv("COMPILER_NAME") }}-{{ os.getenv("COMPILER_VER") }})
 include(../../conan/dependencies)
-include(../../conan/opt/{{ os.getenv("COMPILER_NAME")-linux-hardening)
+include(../../conan/opt/{{ os.getenv("COMPILER_NAME") }}-linux-hardening)
 
 [settings]
 build_type=Release

--- a/ci/conan/linux-hardened
+++ b/ci/conan/linux-hardened
@@ -1,0 +1,6 @@
+include(../../conan/{{ os.getenv("COMPILER_NAME")}}-{{ os.getenv("COMPILER_VER") }})
+include(../../conan/dependencies)
+include(../../conan/opt/linux-hardening)
+
+[settings]
+build_type=Release

--- a/ci/conan/msvc-analyze
+++ b/ci/conan/msvc-analyze
@@ -1,7 +1,6 @@
 include(../../conan/msvc-2022)
 include(../../conan/dependencies)
-include(../../conan/opt/msvc-hardening)
 
 [settings]
-build_type=Release
+build_type=Debug
 

--- a/ci/conan/msvc-asan
+++ b/ci/conan/msvc-asan
@@ -1,6 +1,6 @@
 include(../../conan/msvc-2022)
 include(../../conan/dependencies)
-include(../../conan/opt/msvc-hardening)
+include(../../conan/opt/msvc-address-sanitizer)
 
 [settings]
 build_type=Release

--- a/ci/conan/msvc-hardened
+++ b/ci/conan/msvc-hardened
@@ -1,0 +1,6 @@
+include(../../conan/msvc-2022)
+include(../../conan/dependencies)
+include(../../conan/opt/msvc-hardening)
+
+[settings]
+build_type=Release

--- a/ci/conan/static-analysis
+++ b/ci/conan/static-analysis
@@ -1,7 +1,6 @@
 include(../../conan/{{ os.getenv("COMPILER_NAME")}}-{{ os.getenv("COMPILER_VER") }})
 include(../../conan/dependencies)
-include(../../conan/opt/linux-hardening)
 
 [settings]
-build_type=Release
+build_type=Debug
 


### PR DESCRIPTION
- Add predefined profiles for CI invocations
- Invoke `conan install` only once for all dependencies with correct profile
- Group  action caches per compiler and profile